### PR TITLE
Add Scope Filter and cleanup code

### DIFF
--- a/src/QueryBuilder/InvalidPatternException.php
+++ b/src/QueryBuilder/InvalidPatternException.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace Osi\QueryBuilder;
+
+
+/**
+ * Class InvalidPatternException
+ * @package Osi\QueryBuilder
+ */
+class InvalidPatternException extends \InvalidArgumentException
+{
+
+}

--- a/src/QueryBuilder/Patterns/Between.php
+++ b/src/QueryBuilder/Patterns/Between.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Validator;
 
 /**
  * Class Between
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 class Between implements Pattern
 {
@@ -31,7 +31,7 @@ class Between implements Pattern
     {
         Validator::validate($params, self::RULES);
 
-        if (isset($params['type']) && $params['type'] == "DATE") {
+        if (isset($params['type']) && $params['type'] === "DATE") {
             $params['startRange'] = new Carbon($params['startRange'] ?? '0001-01-01');
             $params['endRange'] = new Carbon($params['endRange'] ?? '9999-12-01');
         }

--- a/src/QueryBuilder/Patterns/In.php
+++ b/src/QueryBuilder/Patterns/In.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Validator;
 
 /**
  * Class In
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 class In implements Pattern
 {

--- a/src/QueryBuilder/Patterns/Like.php
+++ b/src/QueryBuilder/Patterns/Like.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Validator;
 
 /**
  * Class Like
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 class Like implements Pattern
 {

--- a/src/QueryBuilder/Patterns/NullPattern.php
+++ b/src/QueryBuilder/Patterns/NullPattern.php
@@ -6,12 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class NullPattern
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 class NullPattern implements Pattern
 {
-    const PATTERNS = ['NULL'];
-
     /**
      * @param string $field
      * @param array $params

--- a/src/QueryBuilder/Patterns/Pattern.php
+++ b/src/QueryBuilder/Patterns/Pattern.php
@@ -6,11 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Interface Pattern
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 interface Pattern
 {
-
     /**
      * @param string $field
      * @param array $params

--- a/src/QueryBuilder/Patterns/Scope.php
+++ b/src/QueryBuilder/Patterns/Scope.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Osi\QueryBuilder\Patterns;
+
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Class Scope
+ * @package Osi\QueryBuilder\Patterns
+ */
+class Scope implements Pattern
+{
+    const RULES = [
+        'pattern' => 'required|in:SCOPE',
+        'not'     => 'boolean'
+    ];
+
+    /**
+     * @param string $field
+     * @param array $params
+     * @param Builder $queryBuilder
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function apply(string $field, array $params, Builder $queryBuilder): void
+    {
+        Validator::validate($params, self::RULES);
+        if (!$queryBuilder->hasNamedScope($params['name'])) {
+            throw new InvalidArgumentException("Scope is not defined!");
+        }
+        if ($params['not'] ?? false) {
+            throw new InvalidArgumentException("Unsupported negative filter!");
+        }
+        $params = [];
+        if(isset($params['value'])) {
+            $params[] = $params['value'];
+        }
+        $queryBuilder->scopes([
+            $params['name'] => $params
+        ]);
+    }
+}

--- a/src/QueryBuilder/Patterns/Where.php
+++ b/src/QueryBuilder/Patterns/Where.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Validator;
 
 /**
  * Class Where
- * @package QueryBuilder\Patterns
+ * @package Osi\QueryBuilder\Patterns
  */
 class Where implements Pattern
 {
@@ -17,13 +17,13 @@ class Where implements Pattern
         '<' => '>',
         '>' => '<',
         '<=' => '>',
-        '>=' => '<'
+        '>=' => '<',
     ];
 
     const RULES = [
         'value' => 'required',
         'pattern' => 'required|in:=,!=,<,>,<=,>=',
-        'not' => 'boolean'
+        'not' => 'boolean',
     ];
 
     /**
@@ -39,7 +39,7 @@ class Where implements Pattern
         if ($params['not'] ?? false) {
             $params['pattern'] = self::REVERSE_PATTERNS[$params['pattern']];
         }
-        if (isset($params['type']) && $params['type'] == "DATE") {
+        if (isset($params['type']) && $params['type'] === "DATE") {
             $queryBuilder->whereDate($field, $params['pattern'], $params['value']);
         } else {
             $queryBuilder->where($field, $params['pattern'], $params['pattern']);


### PR DESCRIPTION
 Scope filter can be used with custom search functionality with Models that have [Scopes defined](https://laravel.com/docs/8.x/eloquent#local-scopes)

You can pass a filter 
```php
[
    'popular' => [
        'pattern' => 'SCOPE'
    ]
]
```

if you have defined scope:
```php
public function scopePopular($query)
{
    return $query->where('votes', '>', 100);
}
```